### PR TITLE
Removed element from property dependents because it cannot be observed

### DIFF
--- a/addon/components/json-editor.js
+++ b/addon/components/json-editor.js
@@ -36,7 +36,7 @@ export default Ember.Component.extend({
         // Editor is already created and cached.
         return self.get('_editor');
       }
-    }.property('element', 'options', 'json'),
+    }.property('options', 'json'),
 
     /**
     JSON object.


### PR DESCRIPTION
More recent versions of ember use `view.element = null` when destroying a view, which throws:

```
Uncaught Error: Assertion Failed: You must use Ember.set() to set the `element` property
```

This is because you have never actually been able to truly observe a view's `element` property. When you add it as a dependent key, it sets up observers and requires everyone use ember setters, but ember internally does not.

See https://github.com/emberjs/ember.js/issues/11090#issuecomment-100564253 for more info.
