### PR TITLE
jsoneditor now ships with a SVG image

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
 
     app.import(app.bowerDirectory + '/jsoneditor/dist/jsoneditor.js');
     app.import(app.bowerDirectory + '/jsoneditor/dist/jsoneditor.css');
-    app.import(app.bowerDirectory + '/jsoneditor/dist/img/jsoneditor-icons.png', {
+    app.import(app.bowerDirectory + '/jsoneditor/dist/img/jsoneditor-icons.svg', {
       destDir: 'assets/img'
     });
 


### PR DESCRIPTION
jsoneditor now comes with an svg and ember-cli fails when it cannot find the png.

@Glavin001 
