### PR TITLE
Add demoURL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL":"http://blog.glavin.org/ember-jsoneditor/"
   }
 }


### PR DESCRIPTION
Ember Observer.com and Emberaddons.com use this key to provide a link to the demo... 
